### PR TITLE
Upgrade/switch to new cloud watch logs collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ No modules.
 | <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | Name of the EKS cluster | `string` | n/a | yes |
 | <a name="input_enable_cloudwatch_agent"></a> [enable\_cloudwatch\_agent](#input\_enable\_cloudwatch\_agent) | Boolean to enable cloudwatch agent | `bool` | n/a | yes |
 | <a name="input_enable_fluentbit"></a> [enable\_fluentbit](#input\_enable\_fluentbit) | Boolean to enable fluentbit | `bool` | n/a | yes |
+| <a name="input_fluentbit_full_log"></a> [fluentbit\_full\_log](#input\_fluentbit\_full\_log) | Boolean to output full pod/container logs + kubernetes metadata or just the message | `bool` | n/a | yes |
 | <a name="input_log_preserve_legacy_log_group"></a> [log\_preserve\_legacy\_log\_group](#input\_log\_preserve\_legacy\_log\_group) | When true, preserves the legacy log group. Mainly useful to transition to the new log group format | `bool` | `true` | no |
 | <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | Number of days to retain log events | `number` | `90` | no |
 | <a name="input_oidc_host_path"></a> [oidc\_host\_path](#input\_oidc\_host\_path) | n/a | `string` | n/a | yes |

--- a/cloudwatch_agent.tf
+++ b/cloudwatch_agent.tf
@@ -64,7 +64,7 @@ resource "helm_release" "cloudwatch-agent" {
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-cloudwatch-metrics"
   version    = "0.0.10"
-  # appVersion: 1.247350.0b251780
+  # appVersion: 1.300032.2b361
 
   values = [
     templatefile(

--- a/fluentbit.tf
+++ b/fluentbit.tf
@@ -61,7 +61,7 @@ resource "helm_release" "fluentbit" {
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-for-fluent-bit"
   version    = "0.1.32"
-  # appVersion: v2.21.5
+  # appVersion: 2.31.12.20231011
 
   values = [
     templatefile(

--- a/fluentbit.tf
+++ b/fluentbit.tf
@@ -71,6 +71,7 @@ resource "helm_release" "fluentbit" {
         iam_role_arn          = aws_iam_role.fluentbit[0].arn
         cluster_name          = var.eks_cluster_name
         log_retention_in_days = var.log_retention_in_days
+        full_log              = var.fluentbit_full_log ? "" : "log"
       }
     )
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "enable_fluentbit" {
 }
 
 variable "fluentbit_full_log" {
-  type = bool
+  type        = bool
   description = "Boolean to output full pod/container logs + kubernetes metadata or just the message"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "enable_fluentbit" {
   description = "Boolean to enable fluentbit"
 }
 
+variable "fluentbit_full_log" {
+  type = bool
+  description = "Boolean to output full pod/container logs + kubernetes metadata or just the message"
+}
+
 variable "eks_cluster_name" {
   type        = string
   description = "Name of the EKS cluster"

--- a/yamls/fluentbit-values.yaml
+++ b/yamls/fluentbit-values.yaml
@@ -1,36 +1,59 @@
+
 global:
 ## Override the deployment namespace
 #   namespaceOverride:
 
 image:
-  repository: amazon/aws-for-fluent-bit
-  tag: 2.21.5
+  repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
+  tag: 2.31.12.20231011
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podSecurityContext: {}
+# runAsUser: 1000
+# runAsGroup: 1000
+# runAsNonRoot: true
+# seccompProfile:
+#   type: RuntimeDefault
+containerSecurityContext: {}
+# allowPrivilegeEscalation: false
+# capabilities: 
+#   drop:
+#   - ALL
+
+rbac:
+  # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
+  pspEnabled: false
+
 service:
   ## Allow the service to be exposed for monitoring
+  ## For liveness check to work, Health_Check must be set to On
   ## https://docs.fluentbit.io/manual/administration/monitoring
-  # extraService: |
-  #   HTTP_Server  On
-  #   HTTP_Listen  0.0.0.0
-  #   HTTP_PORT    2020
+  extraService: |
+    HTTP_Server  On
+    HTTP_Listen  0.0.0.0
+    HTTP_PORT    2020
+    Health_Check On 
+    HC_Errors_Count 5 
+    HC_Retry_Failure_Count 5 
+    HC_Period 5 
+
   parsersFiles:
     - /fluent-bit/parsers/parsers.conf
-  # additionalParsers: |
+  # extraParsers: |
   #   [PARSER]
   #       Name   logfmt
   #       Format logfmt
 
 input:
+  enabled: true
   tag: "kube.*"
   path: "/var/log/containers/*.log"
   db: "/var/log/flb_kube.db"
-  parser: docker
-  dockerMode: "On"
+  multilineParser: "docker, cri"
   memBufLimit: 5MB
   skipLongLines: "On"
   refreshInterval: 10
@@ -45,6 +68,7 @@ input:
 #       DB           winlog.sqlite
 
 filter:
+  enabled: true
   match: "kube.*"
   kubeURL: "https://kubernetes.default.svc.cluster.local:443"
   mergeLog: "On"
@@ -52,8 +76,17 @@ filter:
   keepLog: "On"
   k8sLoggingParser: "On"
   k8sLoggingExclude: "On"
-  # extraFilters: |
-  #   ...
+  bufferSize: "32k"
+# Uncomment the extraFilters to use Kubelet to get the Metadata instead of talking to API server for large clusters
+# Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
+#  extraFilters: |
+#    Kube_Tag_Prefix     application.var.log.containers.
+#    Labels              Off
+#    Annotations         Off
+#    Use_Kubelet         true
+#    Kubelet_Port        10250
+#    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+#    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
 
 # additionalFilters: |
 #   [FILTER]
@@ -62,15 +95,15 @@ filter:
 #       Exclude log lvl=debug*
 
 cloudWatch:
-  enabled: true
+  enabled: false
   match: "*"
-  region: ${region}
-  logGroupName: "/aws/eks/${cluster_name}/ns/$(kubernetes['namespace_name'])"
-  logStreamName: "$(kubernetes['pod_name'])"
-  logStreamPrefix: 
+  region: "us-east-1"
+  logGroupName: "/aws/eks/fluentbit-cloudwatch/logs"
+  logStreamName:
+  logStreamPrefix: "fluentbit-"
   logKey:
   logFormat:
-  logRetentionDays: ${log_retention_in_days}
+  logRetentionDays:
   roleArn:
   autoCreateGroup: true
   endpoint:
@@ -78,10 +111,34 @@ cloudWatch:
   # extraOutputs: |
   #   ...
 
+cloudWatchLogs:
+  enabled: true
+  match: "*"
+  region: ${region}
+  logGroupName: "/aws/eks/${cluster_name}"
+  logGroupTemplate: /aws/eks/${cluster_name}/ns/$kubernetes['namespace_name']
+  logStreamName: "fluentbit-fallback"
+  logStreamPrefix: ""
+  logStreamTemplate: $kubernetes['pod_name'].$kubernetes['container_name']
+  logKey: ${full_log}
+  logFormat:
+  roleArn:
+  autoCreateGroup: true
+  logRetentionDays: ${log_retention_in_days}
+  endpoint:
+  metricNamespace:
+  metricDimensions:
+  stsEndpoint:
+  autoRetryRequests:
+  externalId:
+  # extraOutputs: |
+  #  log_format json/emf
+  #  worker 1
+
 firehose:
   enabled: false
   match: "*"
-  region: 
+  region: "us-east-1"
   deliveryStream: "my-stream"
   dataKeys:
   roleArn:
@@ -93,7 +150,7 @@ firehose:
 kinesis:
   enabled: false
   match: "*"
-  region: 
+  region: "us-east-1"
   stream: "my-kinesis-stream-name"
   partitionKey: "container_id"
   appendNewline:
@@ -112,6 +169,20 @@ kinesis:
   # extraOutputs: |
   #   ...
 
+kinesis_streams:
+  enabled: false
+  match: "*"
+  region: "us-east-1"
+  stream: "my-kinesis-stream-name"
+  role_arn:
+  endpoint:
+  sts_endpoint:
+  time_key:
+  time_key_format:
+  external_id:
+  auto_retry_requests:
+  log_key: 
+
 elasticsearch:
   enabled: false
   match: "*"
@@ -122,8 +193,78 @@ elasticsearch:
   port: "443"
   retryLimit: 6
   replaceDots: "On"
+  suppressTypeName:
   # extraOutputs: |
   #   Index = my-index
+
+s3:
+  enabled: false
+  match: "*"
+  bucket:
+  region: "us-east-1"
+  jsonDateKey: "date"
+  jsonDateFormat: "iso8601"
+  totalFileSize: "100M"
+  uploadChunkSize: "6M"
+  uploadTimeout: "10m"
+  storeDir: "/tmp/fluent-bit/s3"
+  storeDirLimitSize: 0
+  s3KeyFormat: /pod-logs/$TAG/%Y-%m-%d/%H-%M-%S
+  s3KeyFormatTagDelimiters:
+  staticFilePath: false
+  usePutObject: false
+  roleArn:
+  endpoint:
+  stsEndpoint:
+  cannedAcl:
+  compression:
+  contentType:
+  sendContentMd5: false
+  autoRetryRequests: true
+  logKey:
+  preserveDataOrdering: true
+  storageClass:
+  retryLimit: 1
+  externalId:
+  # extraOutputs: |
+
+opensearch:
+  enabled: false
+  match: "*"
+  host:
+  port: "443"
+  tls: "on"
+  path: ""
+  bufferSize: "5m"
+  pipeline:
+  awsRegion: "us-east-1"
+  awsAuth: "On"
+  awsStsEndpoint:
+  awsRoleArn:
+  awsExternalId:
+  awsServiceName:
+  httpUser:
+  httpPasswd:
+  index: "aws-fluent-bit"
+  type: "_doc"
+  logstashFormat: "off"
+  logstashPrefix: "logstash"
+  logstashDateFormat: "%Y.%m.%d"
+  timeKey: "@timestamp"
+  timeKeyFormat: "%Y-%m-%dT%H:%M:%S"
+  timeKeyNanos: "Off"
+  includeTagKey: "Off"
+  tagKey: "_flb-key"
+  generateId: "Off"
+  idKey:
+  writeOperation: "create"
+  replaceDots: "Off"
+  traceOutput: "Off"
+  traceError: "Off"
+  currentTimeIndex: "Off"
+  logstashPrefixKey:
+  suppressTypeName: "On"
+  # extraOutputs: |
 
 # additionalOutputs: |
 #   [OUTPUT]
@@ -156,8 +297,20 @@ tolerations: []
 
 affinity: {}
 
-annotations: {}
+annotations:
+  {}
   # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
+
+# Specifies if aws-for-fluent-bit should be started in hostNetwork mode.
+#
+# This is required if using a custom CNI where the managed control plane nodes are unable to initiate
+# network connections to the pods, for example using Calico CNI plugin on EKS. This is not required or
+# recommended if using the Amazon VPC CNI plugin.
+
+# Set hostNetwork to true and dnsPolicy to ClusterFirstWithHostNet to use Kubelet to get the Metadata for large clusters
+# Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
+hostNetwork: false
+dnsPolicy: ClusterFirst
 
 env: []
 ## To add extra environment variables to the pods, add as below
@@ -177,7 +330,6 @@ env: []
 #       fieldRef:
 #         fieldPath: spec.nodeName
 
-
 volumes:
   - name: varlog
     hostPath:
@@ -193,26 +345,49 @@ volumeMounts:
     mountPath: /var/lib/docker/containers
     readOnly: true
 
+# For livenessProbe to work - service.extraService must also enable Health_Check On
+livenessProbe:
+  httpGet:
+    path: /api/v1/health
+    port: 2020
+    scheme: HTTP
+  failureThreshold: 2
+  initialDelaySeconds: 30
+  timeoutSeconds: 10
+
+readinessProbe: {}
+  # httpGet:
+  #   path: /api/v1/health
+  #   port: 2020
+  #   scheme: HTTP
+  # failureThreshold: 2
+  # initialDelaySeconds: 30
+  # timeoutSeconds: 10
 
 serviceMonitor:
-  # service:
-  #   type: ClusterIP
-  #   port: 2020
-  #   targetPort: 2020
-  # When set true then use a ServiceMonitor to configure scraping
+  service: 
+    type: ClusterIP
+    port: 2020
+    targetPort: 2020
+    extraPorts: []
+      # - port: 2021
+      #   targetPort: 2021
+      #   protocol: TCP
+      #   name: metrics
+  ## When set true then use a ServiceMonitor to configure scraping
   enabled: false
-  # Set the namespace the ServiceMonitor should be deployed
-  # namespace: monitoring
-  # Set how frequently Prometheus should scrape
-  # interval: 30s
-  # Set path of metrics, e.g /api/v1/metrics/prometheus
-  # telemetryPath: /api/v1/metrics/prometheus
-  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
-  # labels:
-  # Set timeout for scrape
-  # timeout: 10s
-  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-  # relabelings: []
-  # Set of labels to transfer on the Kubernetes Service onto the target.
-  # targetLabels: []
-  # metricRelabelings: []
+  interval: 30s
+  telemetryPath: /api/v1/metrics/prometheus
+  labels:
+    # app: example-application
+    # teamname: example
+  timeout: 10s
+  relabelings: []
+  targetLabels: []
+  metricRelabelings: []
+  extraEndpoints: []
+    # - port: metrics
+    #   path: /metrics
+    #   interval: 30s
+    #   scrapeTimeout: 10s
+    #   scheme: http


### PR DESCRIPTION
## What

Use new values file for aws-for-fluentbit helm release 0.1.32. 
Switch over to using the new CloudWatchLogs collector.
Make log output configurable between full JSON output with kubernetes metadata, or just the log line itself for readability.

## Why

new CloudWatchLogs collector: 

https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit?tab=readme-ov-file#new-higher-performance-core-fluent-bit-plugin

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
